### PR TITLE
west.yml file fix; it compiles now

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -11,5 +11,6 @@ manifest:
     - name: zephyr
       remote: zephyr-github
       repo-path: zephyr
-      revision: v3.7.0
+      # This is nearly 3.7.0, but had a compile error with 3.7.0 so sticking with this for now.
+      revision: 38ad4b6d43cfc875a7ce8fdbe96825aa3e86ce6d
       import: true


### PR DESCRIPTION
Quick fix to the west.yml in order to get the code to compile.
The straight v3.7.0 results in a device tree compile error with the "voltage.c" sensor file.  Not sure why this occurs, so for now designating the explicit version this code was developed under.  Will fix later.